### PR TITLE
fix: export types from build instead of src

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 /node_modules/
 build/test
 src/test
+/.idea
+/.vscode

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export * from './src';
+export * from './build';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f-promise-async",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "license": "MIT",
   "description": "async-await tools base on f-promise for node.js",
   "author": {


### PR DESCRIPTION
@sberthier 

### Proposed change

Changed the way types are exported: `index.d.ts` now points to `build` directory instead of `src` in order to resolve to other  `.d.ts` files in sub-directories instead of resolving to source `.ts` files.

### Reason for change

I encountered a situation where a TS error in the source code of `f-promise-async` caused an error to be thrown at compile time when `f-promise-async` was included as a dependency.

According to https://github.com/microsoft/TypeScript/issues/41883#issuecomment-1758692340, inbound references should resolve to `.d.ts` files and not source `.ts` files.

The tsconfig `skipLibCheck` option can only affect the checking of `.d.ts` files. There are no options to avoid checking `.ts` files. Therefore, it is recommended to export types via `.d.ts` files, so that projects depending on this package can use `skipLibCheck` to choose if they want to perform the check, rather than being forced to do it.